### PR TITLE
Feature/add bazelisk

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,7 +5,7 @@ java_library(
     resources = [
     ],
     deps = [
-        "@junit_junit_4_12//jar",
+        "@junit_junit_4_13_1//jar",
         "@org_hamcrest_hamcrest_core_1_3//jar",
     ],
 )

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ $ mvn kupusoglu.orhan:sloc-maven-plugin:sloc
 [INFO] Inspecting build with total of 1 modules...
 [INFO] Installing Nexus Staging features:
 [INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
-[INFO] 
+[INFO]
 [INFO] ----------------< kupusoglu.orhan:quicksort-duplicates >----------------
 [INFO] Building quicksort-duplicates 0.3.1
 [INFO] --------------------------------[ jar ]---------------------------------
-[INFO] 
+[INFO]
 [INFO] --- sloc-maven-plugin:0.1.4:sloc (default-cli) @ quicksort-duplicates ---
 [INFO] SLOC - directory: /home/orhanku/ME/DEV/OK/quicksort-duplicates/src
 +------------------+--------------------+----------+----------+----------+----------+----------+----------+
@@ -120,23 +120,38 @@ To build and test with Maven:
 ```
 $ mvn clean test
 ```
-### Google Bazel
+### Google Bazel with Bazelisk
 
-To build and test with Bazel:
+The Maven script is migrated to Google Bazel with the [Bazelize Maven Plugin](https://github.com/OrhanKupusoglu/bazelize-maven-plugin).
+But this plugin uses an old version of Bazel, therefore [Bazelisk](https://github.com/bazelbuild/bazelisk) is required.
+
+> Bazelisk<br>
+> A user-friendly launcher for Bazel.
+
+A Bash script, [bazelize.sh](./bazelize.sh), is provided for convenience.
+This script needs to be customized for the path of Bazelisk.
 
 ```
-$ bazel build
+## check options
+$ ./bazelize.sh -h
+usage:
+	./bazelize.sh <option>
+options:
+	migrate to bazel: -m | --migrate | -g | --generate
+	clean bazel:      -c | --clean
+	build with bazel: -b | --build
+	test with bazel:  -t | --test
+	run with bazel:   -r | --run
+requires Bazelisk for Bazel v0.14.1:
+	/home/unknown/dev/bazelisk/bin/bazelisk-linux-amd64
 
-$ bazel test ... --test_output all
+## already migrated, build
+$ ./bazelize.sh -b
+
+## test
+$ ./bazelize.sh -t
 ```
-Or you can use the [bazelize.sh](./bazelize.sh) script:
-```
-$ ./bazelize.sh
-```
-If the pom.xml changes, you can re-genearate the Bazel scripts by the [Bazelize Maven Plugin](https://github.com/OrhanKupusoglu/bazelize-maven-plugin).
-```
-$ ./bazelize.sh -g
-```
+
 &nbsp;
 
 ## Test Results

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 maven_jar(
-    name = "junit_junit_4_12",
-    artifact = "junit:junit:4.12",
+    name = "junit_junit_4_13_1",
+    artifact = "junit:junit:4.13.1",
 )
 maven_jar(
     name = "org_hamcrest_hamcrest_core_1_3",

--- a/bazelize.sh
+++ b/bazelize.sh
@@ -1,47 +1,106 @@
 #!/bin/bash
 
+# customize the following declarations
+# ------------------------------------------------------------------------------
+export USE_BAZEL_VERSION=0.14.1
+BAZEL_BIN=/home/unknown/dev/bazelisk/bin/bazelisk-linux-amd64
 MAIN_CLASS=
+# ------------------------------------------------------------------------------
+
 MAVEN_PLUGIN=kupusoglu.orhan:bazelize-maven-plugin
-MIGRATE=$1
+SEPARATOR=$(printf "%0.s=" {1..80})
+OPTION=$1
 
-bazel clean --expunge
-rm -f bazelize.out bazelize.out.html
+case $OPTION in
+    -h | --help )
+        printf "usage:\n"
+        printf "\t$0 <option>\n"
+        printf "options:\n"
+        printf "\tmigrate to bazel: -m | --migrate | -g | --generate\n"
+        printf "\tclean bazel:      -c | --clean\n"
+        printf "\tbuild with bazel: -b | --build\n"
+        printf "\ttest with bazel:  -t | --test\n"
+        printf "\trun with bazel:   -r | --run\n"
+        printf "requires Bazelisk for Bazel v${USE_BAZEL_VERSION}:\n"
+        printf "\t$BAZEL_BIN\n"
+        exit 0
+        ;;
 
-if [[ $MIGRATE == "-g" ]]
+    -m | --migrate | -g | --generate )
+        MSG="migrate"
+        ;;
+
+    -c | --clean )
+        MSG="clean"
+        ;;
+
+    -b | --build )
+        MSG="build"
+        ;;
+
+    -t | --test )
+        MSG="test"
+        ;;
+
+    -r | --run )
+        MSG="run"
+        ;;
+
+    * )
+        echo "ERROR - unknown option: $OPTION"
+        exit 1
+esac
+
+MSG="$MSG | bazel version: $USE_BAZEL_VERSION"
+
+printf "$SEPARATOR\n"
+printf "== ${MSG}\n"
+printf "$SEPARATOR\n\n"
+
+if [ ! -f $BAZEL_BIN ]
 then
-    mvn ${MAVEN_PLUGIN}:clean -Dexpunge
-    mvn ${MAVEN_PLUGIN}:module
-    mvn ${MAVEN_PLUGIN}:meta
-    mvn ${MAVEN_PLUGIN}:build
-    mvn ${MAVEN_PLUGIN}:workspace
-    mvn ${MAVEN_PLUGIN}:clean
-    mvn ${MAVEN_PLUGIN}:test
-
-    if [[ ! -z $MAIN_CLASS ]]
-    then
-        mvn ${MAVEN_PLUGIN}:binary -DmainClass=${MAIN_CLASS}
-    fi
-
-    msg="migration completed"
-else
-    msg="bazel is ready"
+    echo "ERROR - missing Bazelisk"
+    echo "path: $BAZEL_BIN"
+    exit 2
 fi
 
-printf "\n"
-printf "%0.s=" {1..80}
-printf "\n"
-printf "== ${msg}\n"
-printf "%0.s=" {1..80}
-printf "\n\n"
+case $OPTION in
+    -m | --migrate | -g | --generate )
+        mvn ${MAVEN_PLUGIN}:clean -Dexpunge
+        mvn ${MAVEN_PLUGIN}:module
+        mvn ${MAVEN_PLUGIN}:meta
+        mvn ${MAVEN_PLUGIN}:build
+        mvn ${MAVEN_PLUGIN}:workspace
+        mvn ${MAVEN_PLUGIN}:clean
+        mvn ${MAVEN_PLUGIN}:test
 
-bazel build ... --strict_java_deps=off --profile=bazelize.out
+        if [[ ! -z $MAIN_CLASS ]]
+        then
+            mvn ${MAVEN_PLUGIN}:binary -DmainClass=${MAIN_CLASS}
+        fi
+        ;;
 
-bazel analyze-profile --html bazelize.out
+    -c | --clean )
+        $BAZEL_BIN clean --expunge
+        rm -f bazelize.out bazelize.out.html
+        ;;
 
-bazel test ... --strict_java_deps=off --test_output all
+    -b | --build )
+        $BAZEL_BIN build ... --strict_java_deps=off --profile=bazelize.out
+        $BAZEL_BIN analyze-profile --html bazelize.out
+        ;;
 
-if [[ ! -z $MAIN_CLASS ]]
-then
-    MAIN_BAZEL=${MAIN_CLASS//./_}
-    bazel run $MAIN_BAZEL
-fi
+    -t | --test )
+        $BAZEL_BIN test ... --strict_java_deps=off --test_output all
+        ;;
+
+    -r | --run )
+        if [[ -z $MAIN_CLASS ]]
+        then
+            echo "ERROR: no main class is given"
+        else
+            MAIN_BAZEL=${MAIN_CLASS//./_}
+            $BAZEL_BIN run $MAIN_BAZEL
+        fi
+        ;;
+esac


### PR DESCRIPTION
Since the migration to Bazel is handled for an old version of Bazel, Bazelisk is required.